### PR TITLE
Fix incorrect server response to inventory command

### DIFF
--- a/nitrohack_server/src/winprocs.c
+++ b/nitrohack_server/src/winprocs.c
@@ -481,7 +481,7 @@ static int srv_display_objects(struct nh_objitem *items, int icount, const char 
     jobj = json_pack("{so,si,si,ss}", "items", jarr, "icount", icount,
 		     "how", how, "title", title ? title : "");
     
-    if (how == PICK_NONE) {
+    if (how == PICK_NONE || how == PICK_INVACTION) {
 	add_display_data("display_objects", jobj);
 	return 0;
     }


### PR DESCRIPTION
Sending get_obj_commands while in inventory screen was causing a server error due to this.
